### PR TITLE
Add options to handle other oAuth2 servers, e.g. Google

### DIFF
--- a/src/Configuration/CookieConfiguration.php
+++ b/src/Configuration/CookieConfiguration.php
@@ -7,7 +7,7 @@ namespace AnzuSystems\AuthBundle\Configuration;
 final class CookieConfiguration
 {
     public function __construct(
-        private readonly string $domain,
+        private readonly ?string $domain,
         private readonly bool $secure,
         private readonly string $jwtPayloadCookieName,
         private readonly string $jwtSignatureCookieName,
@@ -18,7 +18,7 @@ final class CookieConfiguration
     ) {
     }
 
-    public function getDomain(): string
+    public function getDomain(): ?string
     {
         return $this->domain;
     }

--- a/src/Configuration/OAuth2Configuration.php
+++ b/src/Configuration/OAuth2Configuration.php
@@ -22,6 +22,7 @@ final class OAuth2Configuration
         private readonly string $ssoClientSecret,
         private readonly string $ssoPublicCert,
         private readonly array $ssoScopes,
+        private readonly string $ssoScopeDelimiter,
         private readonly CacheItemPoolInterface $accessTokenCachePool,
     ) {
     }
@@ -57,7 +58,7 @@ final class OAuth2Configuration
                 'response_type' => 'code',
                 'state' => $state,
                 'redirect_uri' => $this->getSsoRedirectUrl(),
-                'scope' => implode(',', $this->getSsoScopes()),
+                'scope' => implode($this->ssoScopeDelimiter, $this->getSsoScopes()),
             ])
         );
     }

--- a/src/Configuration/OAuth2Configuration.php
+++ b/src/Configuration/OAuth2Configuration.php
@@ -37,8 +37,12 @@ final class OAuth2Configuration
         return $this->ssoAuthorizeUrl;
     }
 
-    public function getSsoUserInfoUrl(string $userId): string
+    public function getSsoUserInfoUrl(?string $userId): string
     {
+        if (!$userId) {
+            return $this->ssoUserInfoUrl;
+        }
+
         return str_replace(self::SSO_USER_ID_PLACEHOLDER_URL, $userId, $this->ssoUserInfoUrl);
     }
 

--- a/src/Configuration/OAuth2Configuration.php
+++ b/src/Configuration/OAuth2Configuration.php
@@ -23,6 +23,7 @@ final class OAuth2Configuration
         private readonly string $ssoPublicCert,
         private readonly array $ssoScopes,
         private readonly string $ssoScopeDelimiter,
+        private readonly bool $considerAccessTokenAsJwt,
         private readonly CacheItemPoolInterface $accessTokenCachePool,
     ) {
     }
@@ -98,5 +99,10 @@ final class OAuth2Configuration
     public function getAccessTokenCachePool(): CacheItemPoolInterface
     {
         return $this->accessTokenCachePool;
+    }
+
+    public function isAccessTokenConsideredJwt(): bool
+    {
+        return $this->considerAccessTokenAsJwt;
     }
 }

--- a/src/Contracts/OAuth2AuthUserRepositoryInterface.php
+++ b/src/Contracts/OAuth2AuthUserRepositoryInterface.php
@@ -7,4 +7,5 @@ namespace AnzuSystems\AuthBundle\Contracts;
 interface OAuth2AuthUserRepositoryInterface
 {
     public function findOneBySsoUserId(string $ssoUserId): ?AnzuAuthUserInterface;
+    public function findOneByEmail(string $email): ?AnzuAuthUserInterface;
 }

--- a/src/Contracts/OAuth2AuthUserRepositoryInterface.php
+++ b/src/Contracts/OAuth2AuthUserRepositoryInterface.php
@@ -7,5 +7,5 @@ namespace AnzuSystems\AuthBundle\Contracts;
 interface OAuth2AuthUserRepositoryInterface
 {
     public function findOneBySsoUserId(string $ssoUserId): ?AnzuAuthUserInterface;
-    public function findOneByEmail(string $email): ?AnzuAuthUserInterface;
+    public function findOneBySsoEmail(string $email): ?AnzuAuthUserInterface;
 }

--- a/src/DependencyInjection/AnzuSystemsAuthExtension.php
+++ b/src/DependencyInjection/AnzuSystemsAuthExtension.php
@@ -100,6 +100,7 @@ final class AnzuSystemsAuthExtension extends Extension
                     ->setArgument('$ssoClientSecret', $oauth2Section['client_secret'])
                     ->setArgument('$ssoPublicCert', $oauth2Section['public_cert'])
                     ->setArgument('$ssoScopes', $oauth2Section['scopes'])
+                    ->setArgument('$ssoScopeDelimiter', $oauth2Section['scope_delimiter'])
                     ->setArgument('$accessTokenCachePool', new Reference($oauth2Section['access_token_cache']))
                 ;
 

--- a/src/DependencyInjection/AnzuSystemsAuthExtension.php
+++ b/src/DependencyInjection/AnzuSystemsAuthExtension.php
@@ -117,6 +117,7 @@ final class AnzuSystemsAuthExtension extends Extension
                     ->register(GrantAccessByOAuth2TokenProcess::class)
                     ->setAutowired(true)
                     ->setAutoconfigured(true)
+                    ->setArgument('$authMethod', $oauth2Section['auth_method'])
                 ;
 
                 $container

--- a/src/DependencyInjection/AnzuSystemsAuthExtension.php
+++ b/src/DependencyInjection/AnzuSystemsAuthExtension.php
@@ -101,6 +101,7 @@ final class AnzuSystemsAuthExtension extends Extension
                     ->setArgument('$ssoPublicCert', $oauth2Section['public_cert'])
                     ->setArgument('$ssoScopes', $oauth2Section['scopes'])
                     ->setArgument('$ssoScopeDelimiter', $oauth2Section['scope_delimiter'])
+                    ->setArgument('$considerAccessTokenAsJwt', $oauth2Section['consider_access_token_as_jwt'])
                     ->setArgument('$accessTokenCachePool', new Reference($oauth2Section['access_token_cache']))
                 ;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -152,7 +152,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('public_cert')->defaultValue('')->end()
                 ->enumNode('scope_delimiter')->values([' ', ','])->defaultValue(',')->end()
                 ->arrayNode('scopes')->scalarPrototype()->end()->end()
-                ->booleanNode('auth_by_email')->defaultFalse()->end()
+                ->booleanNode('consider_access_token_as_jwt')->defaultTrue()->end()
                 ->enumNode('auth_method')
                     ->values([GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_ID, GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_EMAIL])
                     ->defaultValue(GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_ID)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -37,8 +37,9 @@ final class Configuration implements ConfigurationInterface
     {
         return (new TreeBuilder('cookie'))->getRootNode()
             ->isRequired()
+            ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('domain')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('domain')->defaultValue(null)->end()
                 ->booleanNode('secure')->isRequired()->end()
                 ->scalarNode('device_id_name')->defaultValue('anz_di')->end()
                 ->arrayNode('jwt')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AnzuSystems\AuthBundle\DependencyInjection;
 
 use AnzuSystems\AuthBundle\Configuration\OAuth2Configuration;
+use AnzuSystems\AuthBundle\Domain\Process\OAuth2\GrantAccessByOAuth2TokenProcess;
 use AnzuSystems\AuthBundle\Model\Enum\AuthType;
 use AnzuSystems\AuthBundle\Model\Enum\JwtAlgorithm;
 use AnzuSystems\AuthBundle\Model\SsoUserDto;
@@ -151,6 +152,11 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('public_cert')->defaultValue('')->end()
                 ->enumNode('scope_delimiter')->values([' ', ','])->defaultValue(',')->end()
                 ->arrayNode('scopes')->scalarPrototype()->end()->end()
+                ->booleanNode('auth_by_email')->defaultFalse()->end()
+                ->enumNode('auth_method')
+                    ->values([GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_ID, GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_EMAIL])
+                    ->defaultValue(GrantAccessByOAuth2TokenProcess::AUTH_METHOD_SSO_ID)
+                ->end()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -149,6 +149,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('client_id')->defaultValue('')->end()
                 ->scalarNode('client_secret')->defaultValue('')->end()
                 ->scalarNode('public_cert')->defaultValue('')->end()
+                ->enumNode('scope_delimiter')->values([' ', ','])->defaultValue(',')->end()
                 ->arrayNode('scopes')->scalarPrototype()->end()->end()
             ->end()
         ;

--- a/src/Domain/Process/OAuth2/GrantAccessByOAuth2TokenProcess.php
+++ b/src/Domain/Process/OAuth2/GrantAccessByOAuth2TokenProcess.php
@@ -75,7 +75,7 @@ final class GrantAccessByOAuth2TokenProcess
 
                 return $this->createRedirectResponseForRequest($request, UserOAuthLoginState::FailureSsoCommunicationFailed);
             }
-            $authUser = $this->oAuth2AuthUserRepository->findOneByEmail($ssoUser->getEmail());
+            $authUser = $this->oAuth2AuthUserRepository->findOneBySsoEmail($ssoUser->getEmail());
         } else if (self::AUTH_METHOD_SSO_ID === $this->authMethod) {
             $ssoUserId = (string)$ssoJwt->getAccessToken()->claims()->get(RegisteredClaims::SUBJECT);
             $authUser = $this->oAuth2AuthUserRepository->findOneBySsoUserId($ssoUserId);

--- a/src/HttpClient/OAuth2HttpClient.php
+++ b/src/HttpClient/OAuth2HttpClient.php
@@ -46,7 +46,7 @@ final class OAuth2HttpClient
      * @throws UnsuccessfulAccessTokenRequestException
      * @throws UnsuccessfulUserInfoRequestException
      */
-    public function getSsoUserInfo(string $id): SsoUserDto
+    public function getSsoUserInfo(?string $id = null): SsoUserDto
     {
         try {
             $response = $this->client->request(

--- a/src/Model/AccessTokenDto.php
+++ b/src/Model/AccessTokenDto.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\AuthBundle\Model;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lcobucci\JWT\Token\Plain;
+
+final class AccessTokenDto
+{
+    private ?Plain $jwt;
+    private string $accessToken;
+    private DateTimeInterface $expiresAt;
+
+    public function __construct(string $accessToken, DateTimeInterface $expiresAt, ?Plain $accessTokenJwt = null)
+    {
+        $this->accessToken = $accessToken;
+        $this->expiresAt = $expiresAt;
+        $this->jwt = $accessTokenJwt;
+    }
+
+
+    public function getJwt(): ?Plain
+    {
+        return $this->jwt;
+    }
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function getExpiresAt(): DateTimeInterface
+    {
+        return $this->expiresAt;
+    }
+
+    public static function createFromJwtAccessTokenResponse(AccessTokenResponseDto $accessTokenResponseDto): self
+    {
+        $jwt = $accessTokenResponseDto->getAccessToken();
+        /** @var DateTimeInterface $expiresAt */
+        $expiresAt = $jwt->claims()->get('exp');
+
+        return new self($jwt->toString(), $expiresAt, $jwt);
+    }
+
+    public static function createFromOpaqueAccessTokenResponse(OpaqueAccessTokenResponseDto $accessTokenResponseDto): self
+    {
+        $date = (new DateTimeImmutable())->add(new DateInterval('PT' . $accessTokenResponseDto->getExpiresIn() . 'S'));
+
+        return new self($accessTokenResponseDto->getAccessToken(), $date);
+    }
+}

--- a/src/Model/Enum/JwtAlgorithm.php
+++ b/src/Model/Enum/JwtAlgorithm.php
@@ -20,7 +20,7 @@ enum JwtAlgorithm: string implements EnumInterface
     public function signer(): Signer\Ecdsa | Signer\Rsa\Sha256
     {
         return match ($this) {
-            self::ES256 => Signer\Ecdsa\Sha256::create(),
+            self::ES256 => new Signer\Ecdsa\Sha256(),
             self::RS256 => new Signer\Rsa\Sha256(),
         };
     }

--- a/src/Model/OpaqueAccessTokenResponseDto.php
+++ b/src/Model/OpaqueAccessTokenResponseDto.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\AuthBundle\Model;
+
+use AnzuSystems\SerializerBundle\Attributes\Serialize;
+
+final class OpaqueAccessTokenResponseDto
+{
+    #[Serialize(serializedName: 'access_token')]
+    private string $accessToken;
+
+    #[Serialize(serializedName: 'expires_in')]
+    private int $expiresIn;
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function setAccessToken(string $accessToken): self
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
+    }
+
+    public function getExpiresIn(): int
+    {
+        return $this->expiresIn;
+    }
+
+    public function setExpiresIn(int $expiresIn): self
+    {
+        $this->expiresIn = $expiresIn;
+
+        return $this;
+    }
+}

--- a/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
+++ b/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
@@ -102,6 +102,7 @@ final class AnzuSystemsAuthExtensionTest extends TestCase
         self::assertSame('qux-public-cert', $oAuth2ConfArguments['$ssoPublicCert']);
         self::assertSame(['email', 'profile'], $oAuth2ConfArguments['$ssoScopes']);
         self::assertSame(' ', $oAuth2ConfArguments['$ssoScopeDelimiter']);
+        self::assertFalse($oAuth2ConfArguments['$considerAccessTokenAsJwt']);
 
         $this->assertHasDefinition(GrantAccessByOAuth2TokenProcess::class);
         $grantProcessDefinition = $this->configuration->getDefinition(GrantAccessByOAuth2TokenProcess::class);
@@ -156,6 +157,7 @@ authorization:
         - profile
       scope_delimiter: ' '
       auth_method: sso_email
+      consider_access_token_as_jwt: false
 EOF;
         $parser = new Parser();
 

--- a/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
+++ b/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\AuthBundle\Tests\DependencyInjection;
+
+use AnzuSystems\AuthBundle\DependencyInjection\AnzuSystemsAuthExtension;
+use AnzuSystems\AuthBundle\Domain\Process\GrantAccessOnResponseProcess;
+use AnzuSystems\AuthBundle\Domain\Process\RefreshTokenProcess;
+use AnzuSystems\AuthBundle\Event\Listener\LogoutListener;
+use AnzuSystems\AuthBundle\Security\AuthenticationFailureHandler;
+use AnzuSystems\AuthBundle\Security\AuthenticationSuccessHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Parser;
+
+final class AnzuSystemsAuthExtensionTest extends TestCase
+{
+    private ?ContainerBuilder $configuration;
+
+    protected function tearDown(): void
+    {
+        $this->configuration = null;
+    }
+
+    public function testEmptyConfiguration(): void
+    {
+        $this->configuration = new ContainerBuilder();
+        $loader = new AnzuSystemsAuthExtension();
+        $config = $this->getEmptyConfig();
+        $loader->load([$config], $this->configuration);
+
+        $this->assertParameter(null, 'anzu_systems.auth_bundle.cookie.domain');
+        $this->assertParameter(true, 'anzu_systems.auth_bundle.cookie.secure');
+        $this->assertParameter('anz_di', 'anzu_systems.auth_bundle.cookie.device_id_name');
+        $this->assertParameter('anz_jp', 'anzu_systems.auth_bundle.cookie.jwt.payload_part_name');
+        $this->assertParameter('anz_js', 'anzu_systems.auth_bundle.cookie.jwt.signature_part_name');
+        $this->assertParameter('anz_js', 'anzu_systems.auth_bundle.cookie.jwt.signature_part_name');
+
+        $this->assertParameter('anz_rt', 'anzu_systems.auth_bundle.cookie.refresh_token.name');
+        $this->assertParameter(31536000, 'anzu_systems.auth_bundle.cookie.refresh_token.lifetime');
+        $this->assertParameter('anz_rte', 'anzu_systems.auth_bundle.cookie.refresh_token.existence_name');
+
+        $this->assertParameter('anz', 'anzu_systems.auth_bundle.jwt.audience');
+        $this->assertParameter('ES256', 'anzu_systems.auth_bundle.jwt.algorithm');
+        $this->assertParameter('foo_public_cert', 'anzu_systems.auth_bundle.jwt.public_cert');
+        $this->assertParameter('foo_private_cert', 'anzu_systems.auth_bundle.jwt.private_cert');
+        $this->assertParameter(3600, 'anzu_systems.auth_bundle.jwt.lifetime');
+
+        $this->assertNotHasDefinition(AuthenticationSuccessHandler::class);
+        $this->assertNotHasDefinition(AuthenticationFailureHandler::class);
+        $this->assertNotHasDefinition(GrantAccessOnResponseProcess::class);
+        $this->assertNotHasDefinition(RefreshTokenProcess::class);
+        $this->assertNotHasDefinition(LogoutListener::class);
+    }
+
+    public function testFullConfiguration(): void
+    {
+        $this->configuration = new ContainerBuilder();
+        $loader = new AnzuSystemsAuthExtension();
+        $config = $this->getFullConfig();
+        $loader->load([$config], $this->configuration);
+
+        $this->assertParameter('.example.com', 'anzu_systems.auth_bundle.cookie.domain');
+        $this->assertParameter(true, 'anzu_systems.auth_bundle.cookie.secure');
+        $this->assertParameter('anz_di', 'anzu_systems.auth_bundle.cookie.device_id_name');
+        $this->assertParameter('anz_jp', 'anzu_systems.auth_bundle.cookie.jwt.payload_part_name');
+        $this->assertParameter('anz_js', 'anzu_systems.auth_bundle.cookie.jwt.signature_part_name');
+        $this->assertParameter('anz_js', 'anzu_systems.auth_bundle.cookie.jwt.signature_part_name');
+
+        $this->assertParameter('anz_rt', 'anzu_systems.auth_bundle.cookie.refresh_token.name');
+        $this->assertParameter(31536000, 'anzu_systems.auth_bundle.cookie.refresh_token.lifetime');
+        $this->assertParameter('anz_rte', 'anzu_systems.auth_bundle.cookie.refresh_token.existence_name');
+
+        $this->assertParameter('anz', 'anzu_systems.auth_bundle.jwt.audience');
+        $this->assertParameter('ES256', 'anzu_systems.auth_bundle.jwt.algorithm');
+        $this->assertParameter('foo_public_cert', 'anzu_systems.auth_bundle.jwt.public_cert');
+        $this->assertParameter('foo_private_cert', 'anzu_systems.auth_bundle.jwt.private_cert');
+        $this->assertParameter(3600, 'anzu_systems.auth_bundle.jwt.lifetime');
+
+
+        $this->assertHasDefinition(AuthenticationSuccessHandler::class);
+        $this->assertHasDefinition(AuthenticationFailureHandler::class);
+        $this->assertHasDefinition(GrantAccessOnResponseProcess::class);
+        $this->assertHasDefinition(RefreshTokenProcess::class);
+        $this->assertHasDefinition(LogoutListener::class);
+    }
+
+    private function getEmptyConfig(): ?array
+    {
+        $yaml = <<<EOF
+cookie:
+    secure: true
+jwt:
+    public_cert: 'foo_public_cert'
+    private_cert: 'foo_private_cert'
+EOF;
+        $parser = new Parser();
+
+        return $parser->parse($yaml);
+    }
+
+    private function getFullConfig(): array
+    {
+        $yaml = <<<EOF
+cookie:
+    domain: .example.com
+    secure: true
+jwt:
+    public_cert: 'foo_public_cert'
+    private_cert: 'foo_private_cert'
+authorization:
+    enabled: true
+    refresh_token:
+      storage:
+        redis:
+          service_id: SharedTokenStorageRedis
+    auth_redirect_default_url: 'https://example.com/redirect-url'
+    auth_redirect_query_url_allowed_pattern: '.+'
+    type: oauth2
+    oauth2:
+      user_repository_service_id: App\Repository\UserRepository
+      authorize_url: 'https://example.com/authorize-url%'
+      state_token_salt: 'qux-quux'
+      access_token_url: 'https://example.com/access-token-url'
+      redirect_url: 'https://example.com/redirect-url'
+      client_id: anzusystems-forum
+      client_secret: 'bar-secret'
+      public_cert: 'qux-public-cert'
+EOF;
+        $parser = new Parser();
+
+        return $parser->parse($yaml);
+    }
+
+    private function assertParameter($value, string $key): void
+    {
+        self::assertSame($value, $this->configuration->getParameter($key), sprintf('%s parameter is correct', $key));
+    }
+
+    private function assertHasDefinition(string $id): void
+    {
+        self::assertTrue(($this->configuration->hasDefinition($id) || $this->configuration->hasAlias($id)));
+    }
+
+    private function assertNotHasDefinition(string $id): void
+    {
+        self::assertFalse(($this->configuration->hasDefinition($id) || $this->configuration->hasAlias($id)));
+    }
+}

--- a/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
+++ b/tests/DependencyInjection/AnzuSystemsAuthExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\AuthBundle\Tests\DependencyInjection;
 
+use AnzuSystems\AuthBundle\Configuration\OAuth2Configuration;
 use AnzuSystems\AuthBundle\DependencyInjection\AnzuSystemsAuthExtension;
 use AnzuSystems\AuthBundle\Domain\Process\GrantAccessOnResponseProcess;
 use AnzuSystems\AuthBundle\Domain\Process\RefreshTokenProcess;
@@ -52,6 +53,7 @@ final class AnzuSystemsAuthExtensionTest extends TestCase
         $this->assertNotHasDefinition(GrantAccessOnResponseProcess::class);
         $this->assertNotHasDefinition(RefreshTokenProcess::class);
         $this->assertNotHasDefinition(LogoutListener::class);
+        $this->assertNotHasDefinition(OAuth2Configuration::class);
     }
 
     public function testFullConfiguration(): void
@@ -84,6 +86,21 @@ final class AnzuSystemsAuthExtensionTest extends TestCase
         $this->assertHasDefinition(GrantAccessOnResponseProcess::class);
         $this->assertHasDefinition(RefreshTokenProcess::class);
         $this->assertHasDefinition(LogoutListener::class);
+
+        $this->assertHasDefinition(OAuth2Configuration::class);
+
+        $oAuth2ConfigurationDefinition = $this->configuration->getDefinition(OAuth2Configuration::class);
+        $arguments = $oAuth2ConfigurationDefinition->getArguments();
+        self::assertSame('https://example.com/access-token-url', $arguments['$ssoAccessTokenUrl']);
+        self::assertSame('https://example.com/authorize-url', $arguments['$ssoAuthorizeUrl']);
+        self::assertSame('https://example.com/redirect-url', $arguments['$ssoRedirectUrl']);
+        self::assertSame('https://example.com/user-info-url', $arguments['$ssoUserInfoUrl']);
+        self::assertSame('AnzuSystems\AuthBundle\Model\SsoUserDto', $arguments['$ssoUserInfoClass']);
+        self::assertSame('qux', $arguments['$ssoClientId']);
+        self::assertSame('bar-secret', $arguments['$ssoClientSecret']);
+        self::assertSame('qux-public-cert', $arguments['$ssoPublicCert']);
+        self::assertSame(['email', 'profile'], $arguments['$ssoScopes']);
+        self::assertSame(' ', $arguments['$ssoScopeDelimiter']);
     }
 
     private function getEmptyConfig(): ?array
@@ -120,13 +137,18 @@ authorization:
     type: oauth2
     oauth2:
       user_repository_service_id: App\Repository\UserRepository
-      authorize_url: 'https://example.com/authorize-url%'
+      authorize_url: 'https://example.com/authorize-url'
+      user_info_url: 'https://example.com/user-info-url'
       state_token_salt: 'qux-quux'
       access_token_url: 'https://example.com/access-token-url'
       redirect_url: 'https://example.com/redirect-url'
-      client_id: anzusystems-forum
+      client_id: qux
       client_secret: 'bar-secret'
       public_cert: 'qux-public-cert'
+      scopes:
+        - email
+        - profile
+      scope_delimiter: ' '   
 EOF;
         $parser = new Parser();
 


### PR DESCRIPTION
This PR contains these changes:
- allow to specify empty domain for cookies to create the cookies for just one current domain,
- authenticate user by e-mail address instead of SSO ID,
- accept opaque access tokens that are not jwt (for Google oAuth),
- store access token after first request fetched by code,
- allow to specify scope delimiter (some oAuth servers prefer space instead of comma),
- add test for DI configuration.

Possible BC break:
- added method `findOneBySsoEmail` in `src/Contracts/OAuth2AuthUserRepositoryInterface.php`